### PR TITLE
Change of '../pretrained_models/cityscapes/PIDNet_L_Cityscapes_test.p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python models/speed/pidnet_speed.py --a 'pidnet-m' --c 11 --r 720 960
 
 * Put all your images in `samples/` and then run the command below using Cityscapes pretrained PIDNet-L for image format of .png:
 ````bash
-python tools/custom.py --a 'pidnet-l' --p '../pretrained_models/cityscapes/PIDNet_L_Cityscapes_test.pt' --t '.png'
+python tools/custom.py --a 'pidnet-l' --p 'pretrained_models/cityscapes/PIDNet_L_Cityscapes_test.pt' --t '.png'
 ````
 
 ## Citation


### PR DESCRIPTION
Change of '../pretrained_models/cityscapes/PIDNet_L_Cityscapes_test.pt' for 'pretrained_models/cityscapes/PIDNet_L_Cityscapes_test.pt', because if you are into PIDNet folder and run python tools/custom.py --a 'pidnet-l' --p '../pretrained_models/cityscapes/PIDNet_L_Cityscapes_test.pt' --t '.png' it doesn't run because pretrained_models is into PIDNeet folder